### PR TITLE
Check parent agent status during verify. Use ops agent validate command.

### DIFF
--- a/molecule/resources/playbooks/verify_linux.yml
+++ b/molecule/resources/playbooks/verify_linux.yml
@@ -33,36 +33,10 @@
     name: "{{ service_name }}"
     state: started
   register: result
-  when: (agent_type != 'ops-agent') or (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] == '1')
 
 - name: Assert the agent was already running
   assert:
     that: result.changed == false
-  when: (agent_type != 'ops-agent')
-
-- name: Ensure the ops agent fluentbit agent is running
-  service:
-    name: "{{ service_name }}-fluent-bit.service"
-    state: started
-  register: result
-  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
-
-- name: Assert the ops agent fluentbit agent was already running
-  assert:
-    that: result.changed == false
-  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
-
-- name: Ensure the ops agent opentelemetry-collector is running
-  service:
-    name: "{{ service_name }}-opentelemetry-collector.service"
-    state: started
-  register: result
-  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
-
-- name: Assert the ops agent opentelemetry-collector was already running
-  assert:
-    that: result.changed == false
-  when: (agent_type == 'ops-agent' and lookup('env', 'VERSION').split('.')[0] != '1')
 
 - when: main_config_file | length > 0
   block:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,7 +11,7 @@ logging_validation_cmd: '/usr/sbin/google-fluentd -c %s --dry-run'
 
 ops_agent_service_name: google-cloud-ops-agent
 ops-agent_config_path: /etc/google-cloud-ops-agent/config.yaml
-ops-agent_validation_cmd: '/opt/google-cloud-ops-agent/subagents/fluent-bit/bin/fluent-bit -c %s'
+ops-agent_validation_cmd: '/opt/google-cloud-ops-agent/libexec/google_cloud_ops_agent_engine -in /etc/google-cloud-ops-agent/config.yaml'
 
 windows_logging_service_name: StackdriverLogging
 windows_logging_config_path: 'C:\Program Files (x86)\Stackdriver\LoggingAgent\fluent.conf'


### PR DESCRIPTION
This PR allows Ansible to check the parent service https://github.com/GoogleCloudPlatform/ops-agent/pull/132

Switched to ops agent validation command instead of using a sub agent.

This resolves issues here https://github.com/GoogleCloudPlatform/google-cloud-ops-agents-ansible/pull/66